### PR TITLE
Improve locale access examples for i18n routing

### DIFF
--- a/docs/02-pages/02-guides/internationalization.mdx
+++ b/docs/02-pages/02-guides/internationalization.mdx
@@ -213,6 +213,40 @@ When [pre-rendering](/docs/pages/building-your-application/rendering/static-site
 
 When leveraging `getStaticPaths`, the configured locales are provided in the context parameter of the function under `locales` and the configured defaultLocale under `defaultLocale`.
 
+### Client-side via `useRouter()`
+
+You can access locale data in the browser using the [`useRouter()`](https://nextjs.org/docs/pages/api-reference/functions/use-router) hook:
+
+```jsx
+import { useRouter } from 'next/router';
+
+export default function LocaleExample() {
+  const { locale, locales, defaultLocale } = useRouter();
+
+  return (
+      Current locale: {locale}
+      All locales: {locales?.join(', ')}
+      Default locale: {defaultLocale}
+  );
+}
+```
+
+### Server-side via `getStaticProps` or `getServerSideProps`
+
+When using [`getStaticProps`](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-static-props) or [`getServerSideProps`](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-server-side-props), locale values are available through the `context` parameter:
+
+```jsx
+export async function getStaticProps({ locale, locales, defaultLocale }) {
+  return {
+    props: {
+      locale,
+      locales,
+      defaultLocale,
+    },
+  };
+}
+```
+
 ## Transition between locales
 
 You can use `next/link` or `next/router` to transition between locales.


### PR DESCRIPTION
Added concise examples for accessing locale info using useRouter, getStaticProps, and getStaticPaths. Reformatted with JSX blocks for consistency with other sections.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
